### PR TITLE
Add "Growth Tree" study: real-time 3D tree + root growth simulation (Three.js)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,15 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.4.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",
     "@types/node": "^22.1.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/three": "^0.184.1",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.8)
+      three:
+        specifier: ^0.184.0
+        version: 0.184.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.8.0
@@ -66,6 +69,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.0
+      '@types/three':
+        specifier: ^0.184.1
+        version: 0.184.1
       '@vitejs/plugin-react-swc':
         specifier: ^3.5.0
         version: 3.7.0(vite@5.4.0(@types/node@22.1.0))
@@ -105,6 +111,9 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -694,46 +703,55 @@ packages:
     resolution: {integrity: sha512-jMYvxZwGmoHFBTbr12Xc6wOdc2xA5tF5F2q6t7Rcfab68TT0n+r7dgawD4qhPEvasDsVpQi+MgDzj2faOLsZjA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.20.0':
     resolution: {integrity: sha512-1asSTl4HKuIHIB1GcdFHNNZhxAYEdqML/MW4QmPS4G0ivbEcBr1JKlFLKsIRqjSwOBkdItn3/ZDlyvZ/N6KPlw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.20.0':
     resolution: {integrity: sha512-COBb8Bkx56KldOYJfMf6wKeYJrtJ9vEgBRAOkfw6Ens0tnmzPqvlpjZiLgkhg6cA3DGzCmLmmd319pmHvKWWlQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.20.0':
     resolution: {integrity: sha512-+it+mBSyMslVQa8wSPvBx53fYuZK/oLTu5RJoXogjk6x7Q7sz1GNRsXWjn6SwyJm8E/oMjNVwPhmNdIjwP135Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.20.0':
     resolution: {integrity: sha512-yAMvqhPfGKsAxHN8I4+jE0CpLWD8cv4z7CK7BMmhjDuz606Q2tFKkWRY8bHR9JQXYcoLfopo5TTqzxgPUjUMfw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.20.0':
     resolution: {integrity: sha512-qmuxFpfmi/2SUkAw95TtNq/w/I7Gpjurx609OOOV7U4vhvUhBcftcmXwl3rqAek+ADBwSjIC4IVNLiszoj3dPA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.20.0':
     resolution: {integrity: sha512-I0BtGXddHSHjV1mqTNkgUZLnS3WtsqebAXv11D5BZE/gfw5KoyXSAXVqyJximQXNvNzUo4GKlCK/dIwXlz+jlg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.20.0':
     resolution: {integrity: sha512-y+eoL2I3iphUg9tN9GB6ku1FA8kOfmF4oUEWhztDJ4KXJy1agk/9+pejOuZkNFhRwHAOxMsBPLbXPd6mJiCwew==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.20.0':
     resolution: {integrity: sha512-hM3nhW40kBNYUkZb/r9k2FKK+/MnKglX7UYd4ZUy5DJs8/sMsIbqWK2piZtVGE3kcXVNj3B2IrUYROJMMCikNg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.20.0':
     resolution: {integrity: sha512-psegMvP+Ik/Bg7QRJbv8w8PAytPA7Uo8fpFjXyCRHWm6Nt42L+JtoqH8eDQ5hRP7/XW2UiIriy1Z46jf0Oa1kA==}
@@ -776,24 +794,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.7.6':
     resolution: {integrity: sha512-QI8QGL0HGT42tj7F1A+YAzhGkJjUcvvTfI1e2m704W0Enl2/UIK9v5D1zvQzYwusRyKuaQfbeBRYDh0NcLOGLg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.7.6':
     resolution: {integrity: sha512-61AYVzhjuNQAVIKKWOJu3H0/pFD28RYJGxnGg3YMhvRLRyuWNyY5Nyyj2WkKcz/ON+g38Arlz00NT1LDIViRLg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.7.6':
     resolution: {integrity: sha512-hQFznpfLK8XajfAAN9Cjs0w/aVmO7iu9VZvInyrTCRcPqxV5O+rvrhRxKvC1LRMZXr5M6JRSRtepp5w+TK4kAw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.7.6':
     resolution: {integrity: sha512-Aqsd9afykVMuekzjm4X4TDqwxmG4CrzoOSFe0hZrn9SMio72l5eAPnMtYoe5LsIqtjV8MNprLfXaNbjHjTegmA==}
@@ -828,6 +850,9 @@ packages:
   '@swc/types@0.1.12':
     resolution: {integrity: sha512-wBJA+SdtkbFhHjTMYH+dEH1y4VpfGdAc2Kw/LK09i9bXd/K6j6PkDcFCEzb6iVfZMkPRrl/q0e3toqTAJdkIVA==}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
@@ -842,6 +867,15 @@ packages:
 
   '@types/react@18.3.3':
     resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
+
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.184.1':
+    resolution: {integrity: sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@typescript-eslint/eslint-plugin@8.0.1':
     resolution: {integrity: sha512-5g3Y7GDFsJAnY4Yhvk8sZtFfV6YNF2caLzjrRPUBzewjPCaj0yokePB4LJSobyCzGMzjZZYFbwuzbfDHlimXbQ==}
@@ -1154,6 +1188,9 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1336,6 +1373,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   micromatch@4.0.7:
     resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
@@ -1640,6 +1680,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  three@0.184.0:
+    resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -1769,6 +1812,8 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -2361,6 +2406,8 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/estree@1.0.5': {}
 
   '@types/node@22.1.0':
@@ -2377,6 +2424,19 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
+
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.184.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
+  '@types/webxr@0.5.24': {}
 
   '@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)':
     dependencies:
@@ -2737,6 +2797,8 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fflate@0.8.3: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -2896,6 +2958,8 @@ snapshots:
       react: 18.3.1
 
   merge2@1.4.1: {}
+
+  meshoptimizer@1.1.1: {}
 
   micromatch@4.0.7:
     dependencies:
@@ -3201,6 +3265,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  three@0.184.0: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,30 @@
 import { Portal } from '@/components/portal/portal';
 import { Study } from '@/components/Study';
+import { StudySwitcher } from '@/components/StudySwitcher';
 import { ThemeProvider } from '@/components/theme/ThemeProvider';
-import { studyLSystem } from '@/studies/l-systems/index';
+import { DEFAULT_STUDY_ID, getStudy } from '@/studies/registry';
+import { useState } from 'react';
 
 function App() {
+  const [activeId, setActiveId] = useState(DEFAULT_STUDY_ID);
+  const study = getStudy(activeId);
+
   return (
     <ThemeProvider>
       <div className="w-full h-svh">
-        {/* TODO: make this dynamic based on the set of studies */}
         <Study
-          path={[{ title: studyLSystem.title, href: window.location.href }]}
-          sidebarChildren={<div id={Portal.Sidebar} />}
+          path={[{ title: study.title, href: window.location.href }]}
+          sidebarChildren={
+            <>
+              <StudySwitcher activeId={activeId} onChange={setActiveId} />
+              <div id={Portal.Sidebar} />
+            </>
+          }
         >
-          {studyLSystem.component}
+          {/* keying by id remounts the study so its engine fully resets */}
+          <div key={study.id} className="h-full">
+            {study.component}
+          </div>
         </Study>
       </div>
     </ThemeProvider>

--- a/src/components/StudySwitcher.tsx
+++ b/src/components/StudySwitcher.tsx
@@ -1,0 +1,33 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { studies } from '@/studies/registry';
+
+interface StudySwitcherProps {
+  activeId: string;
+  onChange: (id: string) => void;
+}
+
+/** Sidebar dropdown for switching between the registered studies. */
+export function StudySwitcher({ activeId, onChange }: StudySwitcherProps) {
+  return (
+    <div className="p-4 border-b border-neutral-300/60 dark:border-neutral-700/60">
+      <Select value={activeId} onValueChange={onChange}>
+        <SelectTrigger className="bg-white/40 dark:bg-neutral-900/40">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {studies.map((study) => (
+            <SelectItem key={study.id} value={study.id}>
+              {study.title}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/components/ui/MetricBar.tsx
+++ b/src/components/ui/MetricBar.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils';
+
+interface MetricBarProps {
+  label: string;
+  /** Current value (already scaled into the same unit as `max`). */
+  value: number;
+  max: number;
+  /** Tailwind background color class for the fill, e.g. "bg-amber-400". */
+  color: string;
+  /** Optional formatted value shown on the right (defaults to value.toFixed(1)). */
+  display?: string;
+  unit?: string;
+}
+
+/** Compact labelled progress bar used in the live feedback panel. */
+export function MetricBar({
+  label,
+  value,
+  max,
+  color,
+  display,
+  unit,
+}: MetricBarProps) {
+  const pct = Math.max(0, Math.min(1, max > 0 ? value / max : 0)) * 100;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between">
+        <span className="text-xs text-neutral-600 dark:text-neutral-400">
+          {label}
+        </span>
+        <span className="font-mono text-xs tabular-nums text-neutral-800 dark:text-neutral-200">
+          {display ?? value.toFixed(1)}
+          {unit && <span className="ml-0.5 text-neutral-500">{unit}</span>}
+        </span>
+      </div>
+      <div className="h-1.5 overflow-hidden rounded-full bg-neutral-300/50 dark:bg-neutral-700/50">
+        <div
+          className={cn('h-full rounded-full transition-[width] duration-150', color)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,73 @@
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+
+export interface ToggleOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface BaseProps<T extends string> {
+  label?: string;
+  options: ToggleOption<T>[];
+  className?: string;
+}
+
+interface SingleProps<T extends string> extends BaseProps<T> {
+  type?: 'single';
+  value: T;
+  onChange: (value: T) => void;
+}
+
+interface MultipleProps<T extends string> extends BaseProps<T> {
+  type: 'multiple';
+  values: T[];
+  onToggle: (value: T) => void;
+}
+
+type ToggleGroupProps<T extends string> = SingleProps<T> | MultipleProps<T>;
+
+/**
+ * A lightweight segmented button group built on the existing Button styling.
+ * Supports a single-select mode (radio-like) and a multiple-select mode
+ * (independent toggles), matching the neutral / glassy theme of the app.
+ */
+export function ToggleGroup<T extends string>(props: ToggleGroupProps<T>) {
+  const { label, options, className } = props;
+
+  const isActive = (value: T) =>
+    props.type === 'multiple'
+      ? props.values.includes(value)
+      : props.value === value;
+
+  const handle = (value: T) => {
+    if (props.type === 'multiple') props.onToggle(value);
+    else props.onChange(value);
+  };
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      {label && <Label className="text-sm">{label}</Label>}
+      <div className="inline-flex w-full p-0.5 rounded-lg bg-neutral-200/60 dark:bg-neutral-800/60">
+        {options.map((opt) => {
+          const active = isActive(opt.value);
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              aria-pressed={active}
+              onClick={() => handle(opt.value)}
+              className={cn(
+                'flex-1 px-2 py-1 text-xs font-medium rounded-md transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-950 dark:focus-visible:ring-neutral-300',
+                active
+                  ? 'bg-white text-neutral-900 shadow-sm dark:bg-neutral-50 dark:text-neutral-900'
+                  : 'text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100'
+              )}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/studies/registry.ts
+++ b/src/studies/registry.ts
@@ -1,0 +1,19 @@
+import { Study } from '@/studies/study';
+import { studyLSystem } from '@/studies/l-systems/index';
+import { studyTreeGrowth } from '@/studies/tree-growth/index';
+
+export interface RegisteredStudy extends Study {
+  id: string;
+}
+
+/** The ordered set of studies available in the app. */
+export const studies: RegisteredStudy[] = [
+  { id: 'tree-growth', ...studyTreeGrowth },
+  { id: 'l-systems', ...studyLSystem },
+];
+
+export const DEFAULT_STUDY_ID = studies[0].id;
+
+export function getStudy(id: string): RegisteredStudy {
+  return studies.find((s) => s.id === id) ?? studies[0];
+}

--- a/src/studies/tree-growth/TreeGrowth.tsx
+++ b/src/studies/tree-growth/TreeGrowth.tsx
@@ -1,0 +1,325 @@
+import { InPortal } from '@/components/portal/InPortal';
+import { Button } from '@/components/ui/button';
+import { MetricBar } from '@/components/ui/MetricBar';
+import { SliderWithDiscreteInput } from '@/components/ui/SliderWithDiscreteInput';
+import { ToggleGroup } from '@/components/ui/toggle-group';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { TreeRenderer } from './renderer';
+import { TreeSimulation } from './simulation';
+import {
+  Allocation,
+  DEFAULT_PARAMS,
+  EMPTY_METRICS,
+  LightDir,
+  Metrics,
+  SimParams,
+  Soil,
+} from './types';
+
+const PRODUCTION_MAX = 16;
+const UPTAKE_MAX = 24;
+
+export function TreeGrowth() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const simRef = useRef<TreeSimulation | null>(null);
+  const rendererRef = useRef<TreeRenderer | null>(null);
+  const paramsRef = useRef<SimParams>({
+    ...DEFAULT_PARAMS,
+    show: { ...DEFAULT_PARAMS.show },
+  });
+  const regrowTimer = useRef<number | null>(null);
+
+  const [ui, setUi] = useState<SimParams>(paramsRef.current);
+  const [metrics, setMetrics] = useState<Metrics>(EMPTY_METRICS);
+
+  // ----------------------------------------------------- engine lifecycle
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const sim = new TreeSimulation(paramsRef.current);
+    const renderer = new TreeRenderer(container);
+    simRef.current = sim;
+    rendererRef.current = renderer;
+
+    let raf = 0;
+    let last = performance.now();
+    let taperTimer = 0;
+    let metricTimer = 0;
+    let fpsFrames = 0;
+    let fpsTime = 0;
+
+    const loop = (now: number) => {
+      raf = requestAnimationFrame(loop);
+      let dt = (now - last) / 1000;
+      last = now;
+      if (dt > 0.05) dt = 0.05; // clamp after tab-switch / GC pauses
+
+      sim.setParams(paramsRef.current);
+      sim.step(dt);
+      renderer.syncStructure(sim);
+
+      taperTimer += dt;
+      if (taperTimer >= 0.25) {
+        taperTimer = 0;
+        renderer.refreshTaper(sim);
+      }
+
+      renderer.syncLeaves(sim, paramsRef.current.leafSize);
+      renderer.syncAttractors(sim, paramsRef.current.show.attractors);
+      renderer.applyParams(paramsRef.current);
+      renderer.setTime(now / 1000);
+      renderer.render();
+
+      fpsFrames++;
+      fpsTime += dt;
+      metricTimer += dt;
+      if (metricTimer >= 0.15) {
+        const fps = fpsTime > 0 ? fpsFrames / fpsTime : 0;
+        setMetrics(sim.getMetrics(fps));
+        metricTimer = 0;
+        fpsFrames = 0;
+        fpsTime = 0;
+      }
+    };
+    raf = requestAnimationFrame(loop);
+
+    const resize = () => renderer.resize();
+    const observer = new ResizeObserver(resize);
+    observer.observe(container);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      observer.disconnect();
+      renderer.dispose();
+      simRef.current = null;
+      rendererRef.current = null;
+    };
+  }, []);
+
+  // --------------------------------------------------------- param updates
+  const update = useCallback((patch: Partial<SimParams>) => {
+    setUi((prev) => {
+      const next: SimParams = { ...prev, ...patch };
+      paramsRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const regrow = useCallback(() => {
+    const sim = simRef.current;
+    const renderer = rendererRef.current;
+    if (!sim || !renderer) return;
+    renderer.resetView();
+    sim.reset(paramsRef.current);
+  }, []);
+
+  // structural params (attractor layout) need a debounced regrow
+  const updateStructural = useCallback(
+    (patch: Partial<SimParams>) => {
+      update(patch);
+      if (regrowTimer.current) window.clearTimeout(regrowTimer.current);
+      regrowTimer.current = window.setTimeout(() => regrow(), 280);
+    },
+    [update, regrow]
+  );
+
+  useEffect(
+    () => () => {
+      if (regrowTimer.current) window.clearTimeout(regrowTimer.current);
+    },
+    []
+  );
+
+  const toggleLayer = (key: 'leaves' | 'roots' | 'attractors') =>
+    update({ show: { ...ui.show, [key]: !ui.show[key] } });
+
+  const limitingLabel =
+    metrics.limiting === 'carbon'
+      ? 'Carbon-limited'
+      : metrics.limiting === 'water'
+        ? 'Water-limited'
+        : 'Balanced';
+  const limitingColor =
+    metrics.limiting === 'carbon'
+      ? 'text-amber-500'
+      : metrics.limiting === 'water'
+        ? 'text-sky-500'
+        : 'text-emerald-500';
+
+  return (
+    <>
+      <InPortal>
+        <div className="flex flex-col p-4 space-y-5 overflow-y-auto max-h-[calc(100svh-2rem)]">
+          {/* live feedback panel */}
+          <section className="p-3 space-y-2.5 border rounded-lg border-neutral-300/60 dark:border-neutral-700/60 bg-neutral-100/40 dark:bg-neutral-800/30">
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold">Resource flux</h2>
+              <span className={`text-xs font-medium ${limitingColor}`}>
+                {limitingLabel}
+              </span>
+            </div>
+            <MetricBar
+              label="Photosynthesis"
+              value={metrics.production}
+              max={PRODUCTION_MAX}
+              color="bg-amber-400"
+              display={metrics.production.toFixed(1)}
+              unit="C/s"
+            />
+            <MetricBar
+              label="Nutrient uptake"
+              value={metrics.uptake}
+              max={UPTAKE_MAX}
+              color="bg-sky-400"
+              display={metrics.uptake.toFixed(1)}
+              unit="W/s"
+            />
+            <MetricBar
+              label="Carbon reserve"
+              value={metrics.carbon}
+              max={metrics.carbonCap}
+              color="bg-amber-500/70"
+            />
+            <MetricBar
+              label="Water reserve"
+              value={metrics.water}
+              max={metrics.waterCap}
+              color="bg-sky-500/70"
+            />
+            <div className="grid grid-cols-4 gap-1 pt-1 text-center">
+              <Stat label="branch" value={metrics.branches} />
+              <Stat label="leaf" value={metrics.leaves} />
+              <Stat label="root" value={metrics.roots} />
+              <Stat label="fps" value={Math.round(metrics.fps)} />
+            </div>
+          </section>
+
+          {/* environment sliders */}
+          <SliderWithDiscreteInput
+            label="Sunlight"
+            min={0}
+            max={1.5}
+            step={0.01}
+            value={ui.sunlight}
+            onChange={(v) => update({ sunlight: v })}
+          />
+          <SliderWithDiscreteInput
+            label="Soil Nutrients"
+            min={0}
+            max={1.5}
+            step={0.01}
+            value={ui.nutrients}
+            onChange={(v) => update({ nutrients: v })}
+          />
+          <SliderWithDiscreteInput
+            label="Growth Speed"
+            min={0.1}
+            max={3}
+            step={0.05}
+            value={ui.growthSpeed}
+            onChange={(v) => update({ growthSpeed: v })}
+          />
+          <SliderWithDiscreteInput
+            label="Branch Density"
+            min={0.3}
+            max={2}
+            step={0.05}
+            value={ui.branchDensity}
+            onChange={(v) => updateStructural({ branchDensity: v })}
+          />
+          <SliderWithDiscreteInput
+            label="Wind"
+            min={0}
+            max={1}
+            step={0.01}
+            value={ui.wind}
+            onChange={(v) => update({ wind: v })}
+          />
+          <SliderWithDiscreteInput
+            label="Leaf Size"
+            min={0.3}
+            max={2}
+            step={0.05}
+            value={ui.leafSize}
+            onChange={(v) => update({ leafSize: v })}
+          />
+
+          {/* toggle groups */}
+          <ToggleGroup<Allocation>
+            label="Allocation"
+            value={ui.allocation}
+            onChange={(v) => update({ allocation: v })}
+            options={[
+              { value: 'balanced', label: 'Balanced' },
+              { value: 'shoots', label: 'Shoots' },
+              { value: 'roots', label: 'Roots' },
+            ]}
+          />
+          <ToggleGroup<LightDir>
+            label="Light Direction"
+            value={ui.lightDir}
+            onChange={(v) => update({ lightDir: v })}
+            options={[
+              { value: 'left', label: 'Left' },
+              { value: 'top', label: 'Top' },
+              { value: 'right', label: 'Right' },
+            ]}
+          />
+          <ToggleGroup<Soil>
+            label="Soil"
+            value={ui.soil}
+            onChange={(v) => updateStructural({ soil: v })}
+            options={[
+              { value: 'poor', label: 'Poor' },
+              { value: 'normal', label: 'Normal' },
+              { value: 'rich', label: 'Rich' },
+            ]}
+          />
+          <ToggleGroup
+            type="multiple"
+            label="Show"
+            values={(['leaves', 'roots', 'attractors'] as const).filter(
+              (k) => ui.show[k]
+            )}
+            onToggle={(v) => toggleLayer(v)}
+            options={[
+              { value: 'leaves', label: 'Leaves' },
+              { value: 'roots', label: 'Roots' },
+              { value: 'attractors', label: 'Sites' },
+            ]}
+          />
+
+          {/* actions */}
+          <div className="flex gap-2 !mt-7">
+            <Button
+              variant="outline"
+              className="flex-1"
+              onClick={() => update({ paused: !ui.paused })}
+            >
+              {ui.paused ? 'Resume' : 'Pause'}
+            </Button>
+            <Button className="flex-1" onClick={regrow}>
+              Replant
+            </Button>
+          </div>
+        </div>
+      </InPortal>
+
+      <div ref={containerRef} className="w-full h-full" />
+    </>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="flex flex-col">
+      <span className="font-mono text-sm tabular-nums text-neutral-800 dark:text-neutral-100">
+        {value}
+      </span>
+      <span className="text-[10px] uppercase tracking-wide text-neutral-500">
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/src/studies/tree-growth/index.tsx
+++ b/src/studies/tree-growth/index.tsx
@@ -1,0 +1,9 @@
+import { Study } from '@/studies/study';
+import { TreeGrowth } from './TreeGrowth';
+
+export const studyTreeGrowth: Study = {
+  component: <TreeGrowth />,
+  title: 'Growth Tree',
+  description:
+    'Real-time tree + root growth driven by a photosynthesis / nutrient-uptake economy',
+};

--- a/src/studies/tree-growth/renderer.ts
+++ b/src/studies/tree-growth/renderer.ts
@@ -1,0 +1,416 @@
+/**
+ * TreeRenderer — Three.js view for the growth simulation.
+ *
+ * Branches, roots and leaves are each drawn with a single InstancedMesh backed
+ * by a preallocated instance buffer. Only newly grown segments are written each
+ * frame; the (more expensive) full re-write that picks up pipe-model radius
+ * changes is throttled by the render loop. Wind is a GPU-side vertex
+ * displacement driven by one `uTime` uniform, so it costs effectively nothing.
+ */
+
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { TreeSimulation } from './simulation';
+import {
+  MAX_ATTRACTORS,
+  MAX_LEAVES,
+  MAX_ROOT_SEG,
+  MAX_SHOOT_SEG,
+  SimParams,
+} from './types';
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+interface WindUniforms {
+  uTime: { value: number };
+  uWind: { value: number };
+  uWindDir: { value: THREE.Vector2 };
+}
+
+export class TreeRenderer {
+  readonly renderer: THREE.WebGLRenderer;
+  readonly scene: THREE.Scene;
+  readonly camera: THREE.PerspectiveCamera;
+  readonly controls: OrbitControls;
+
+  private readonly branches: THREE.InstancedMesh;
+  private readonly roots: THREE.InstancedMesh;
+  private readonly leaves: THREE.InstancedMesh;
+  private readonly canopyPoints: THREE.Points;
+  private readonly rootPoints: THREE.Points;
+  private readonly sun: THREE.DirectionalLight;
+
+  // instance bookkeeping
+  private shootInst = 0;
+  private rootInst = 0;
+  private leafInst = 0;
+  private syncedNodes = 0;
+  private readonly shootNodeOf = new Int32Array(MAX_SHOOT_SEG);
+  private readonly rootNodeOf = new Int32Array(MAX_ROOT_SEG);
+  private lastStructureVersion = -1;
+  private lastTaperVersion = -1;
+  private lastLeafSize = -1;
+
+  private readonly wind: WindUniforms = {
+    uTime: { value: 0 },
+    uWind: { value: 0.35 },
+    uWindDir: { value: new THREE.Vector2(1, 0.35).normalize() },
+  };
+
+  private readonly dummy = new THREE.Object3D();
+  private readonly dir = new THREE.Vector3();
+  private readonly mid = new THREE.Vector3();
+  private readonly quat = new THREE.Quaternion();
+  private readonly disposables: { dispose(): void }[] = [];
+
+  constructor(private container: HTMLElement) {
+    const width = container.clientWidth || 1;
+    const height = container.clientHeight || 1;
+
+    this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.renderer.setSize(width, height);
+    this.renderer.shadowMap.enabled = false;
+    container.appendChild(this.renderer.domElement);
+    this.renderer.domElement.style.display = 'block';
+
+    this.scene = new THREE.Scene();
+    this.scene.background = new THREE.Color(0x0c1016);
+    this.scene.fog = new THREE.Fog(0x0c1016, 42, 95);
+
+    this.camera = new THREE.PerspectiveCamera(50, width / height, 0.1, 400);
+    this.camera.position.set(20, 15, 26);
+
+    this.controls = new OrbitControls(this.camera, this.renderer.domElement);
+    this.controls.enableDamping = true;
+    this.controls.dampingFactor = 0.08;
+    this.controls.target.set(0, 8, 0);
+    this.controls.maxPolarAngle = Math.PI * 0.92;
+    this.controls.minDistance = 6;
+    this.controls.maxDistance = 120;
+
+    // --- lighting ---------------------------------------------------------
+    const hemi = new THREE.HemisphereLight(0xbfd4ff, 0x3a2c1f, 0.85);
+    this.scene.add(hemi);
+    this.sun = new THREE.DirectionalLight(0xfff1d0, 1.4);
+    this.sun.position.set(6, 20, 8);
+    this.scene.add(this.sun);
+    this.scene.add(new THREE.AmbientLight(0x404a5a, 0.6));
+
+    // --- ground + soil hint ----------------------------------------------
+    const ground = new THREE.Mesh(
+      new THREE.CircleGeometry(60, 48).rotateX(-Math.PI / 2),
+      new THREE.MeshStandardMaterial({
+        color: 0x4a361f,
+        roughness: 1,
+        transparent: true,
+        opacity: 0.45,
+        side: THREE.DoubleSide,
+      })
+    );
+    this.scene.add(ground);
+    this.disposables.push(ground.geometry, ground.material as THREE.Material);
+
+    const grid = new THREE.GridHelper(60, 30, 0x2a3340, 0x1c232d);
+    (grid.material as THREE.Material).transparent = true;
+    (grid.material as THREE.Material).opacity = 0.25;
+    this.scene.add(grid);
+    this.disposables.push(grid.geometry, grid.material as THREE.Material);
+
+    // --- branch / root / leaf meshes -------------------------------------
+    const branchGeo = new THREE.CylinderGeometry(1, 1, 1, 6, 1);
+    const branchMat = this.makeWindMaterial(0x6b4a2f, 0.012, 0.85);
+    this.branches = new THREE.InstancedMesh(branchGeo, branchMat, MAX_SHOOT_SEG);
+    this.branches.count = 0;
+    this.branches.frustumCulled = false;
+    this.scene.add(this.branches);
+    this.disposables.push(branchGeo, branchMat);
+
+    const rootGeo = new THREE.CylinderGeometry(1, 1, 1, 5, 1);
+    const rootMat = this.makeWindMaterial(0x7a5a3a, 0, 1);
+    rootMat.transparent = true;
+    rootMat.opacity = 0.92;
+    this.roots = new THREE.InstancedMesh(rootGeo, rootMat, MAX_ROOT_SEG);
+    this.roots.count = 0;
+    this.roots.frustumCulled = false;
+    this.scene.add(this.roots);
+    this.disposables.push(rootGeo, rootMat);
+
+    const leafGeo = new THREE.CircleGeometry(0.5, 5);
+    const leafMat = this.makeWindMaterial(0x4e9a3d, 0.05, 1);
+    leafMat.side = THREE.DoubleSide;
+    leafMat.roughness = 0.7;
+    this.leaves = new THREE.InstancedMesh(leafGeo, leafMat, MAX_LEAVES);
+    this.leaves.count = 0;
+    this.leaves.frustumCulled = false;
+    this.leaves.instanceColor = new THREE.InstancedBufferAttribute(
+      new Float32Array(MAX_LEAVES * 3),
+      3
+    );
+    this.scene.add(this.leaves);
+    this.disposables.push(leafGeo, leafMat);
+
+    // --- attractor point clouds ------------------------------------------
+    this.canopyPoints = this.makePoints(0xffe08a, 0.5);
+    this.rootPoints = this.makePoints(0x5fd0e0, 0.45);
+    this.scene.add(this.canopyPoints);
+    this.scene.add(this.rootPoints);
+  }
+
+  private makeWindMaterial(
+    color: number,
+    swayMul: number,
+    rough: number
+  ): THREE.MeshStandardMaterial {
+    const mat = new THREE.MeshStandardMaterial({
+      color,
+      roughness: rough,
+      metalness: 0,
+    });
+    mat.onBeforeCompile = (shader) => {
+      shader.uniforms.uTime = this.wind.uTime;
+      shader.uniforms.uWind = this.wind.uWind;
+      shader.uniforms.uWindDir = this.wind.uWindDir;
+      shader.vertexShader =
+        'uniform float uTime;\nuniform float uWind;\nuniform vec2 uWindDir;\n' +
+        shader.vertexShader.replace(
+          '#include <begin_vertex>',
+          `#include <begin_vertex>
+          {
+            float wy = instanceMatrix[3][1];
+            float wx = instanceMatrix[3][0];
+            float h = max(0.0, wy);
+            float phase = uTime * 1.5 + wy * 0.18 + wx * 0.12;
+            float s = sin(phase) + 0.4 * sin(phase * 2.3 + 1.0);
+            float amp = uWind * h * ${swayMul.toFixed(4)};
+            transformed.x += s * amp * uWindDir.x;
+            transformed.z += s * amp * uWindDir.y;
+          }`
+        );
+    };
+    return mat;
+  }
+
+  private makePoints(color: number, size: number): THREE.Points {
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute(
+      'position',
+      new THREE.BufferAttribute(new Float32Array(MAX_ATTRACTORS * 3), 3)
+    );
+    geo.setDrawRange(0, 0);
+    const mat = new THREE.PointsMaterial({
+      color,
+      size,
+      transparent: true,
+      opacity: 0.8,
+      depthWrite: false,
+    });
+    this.disposables.push(geo, mat);
+    const pts = new THREE.Points(geo, mat);
+    pts.frustumCulled = false;
+    return pts;
+  }
+
+  // ----------------------------------------------------------------- syncing
+  /** On a reset the simulation rewinds; drop all instances and start over. */
+  resetView(): void {
+    this.shootInst = 0;
+    this.rootInst = 0;
+    this.leafInst = 0;
+    this.syncedNodes = 0;
+    this.branches.count = 0;
+    this.roots.count = 0;
+    this.leaves.count = 0;
+    this.lastStructureVersion = -1;
+    this.lastTaperVersion = -1;
+    this.lastLeafSize = -1;
+  }
+
+  syncStructure(sim: TreeSimulation): void {
+    if (sim.structureVersion === this.lastStructureVersion) return;
+    this.lastStructureVersion = sim.structureVersion;
+
+    // append instances for newly created nodes
+    for (let i = this.syncedNodes; i < sim.nodeCount; i++) {
+      const parent = sim.parent[i];
+      if (parent < 0) continue;
+      if (sim.kind[i] === 1) {
+        if (this.rootInst >= MAX_ROOT_SEG) continue;
+        this.rootNodeOf[this.rootInst] = i;
+        this.writeSegment(this.roots, this.rootInst, sim, i);
+        this.rootInst++;
+      } else {
+        if (this.shootInst >= MAX_SHOOT_SEG) continue;
+        this.shootNodeOf[this.shootInst] = i;
+        this.writeSegment(this.branches, this.shootInst, sim, i);
+        this.shootInst++;
+      }
+    }
+    this.syncedNodes = sim.nodeCount;
+    this.branches.count = this.shootInst;
+    this.roots.count = this.rootInst;
+    this.branches.instanceMatrix.needsUpdate = true;
+    this.roots.instanceMatrix.needsUpdate = true;
+  }
+
+  /** Re-write every segment matrix to pick up updated pipe-model radii. */
+  refreshTaper(sim: TreeSimulation): void {
+    if (sim.structureVersion === this.lastTaperVersion) return;
+    this.lastTaperVersion = sim.structureVersion;
+    sim.refreshTaper();
+    for (let k = 0; k < this.shootInst; k++) {
+      this.writeSegment(this.branches, k, sim, this.shootNodeOf[k]);
+    }
+    for (let k = 0; k < this.rootInst; k++) {
+      this.writeSegment(this.roots, k, sim, this.rootNodeOf[k]);
+    }
+    this.branches.instanceMatrix.needsUpdate = true;
+    this.roots.instanceMatrix.needsUpdate = true;
+  }
+
+  private writeSegment(
+    mesh: THREE.InstancedMesh,
+    inst: number,
+    sim: TreeSimulation,
+    node: number
+  ): void {
+    const p = sim.parent[node];
+    const ax = sim.px[p];
+    const ay = sim.py[p];
+    const az = sim.pz[p];
+    const bx = sim.px[node];
+    const by = sim.py[node];
+    const bz = sim.pz[node];
+    this.dir.set(bx - ax, by - ay, bz - az);
+    const len = this.dir.length() || 0.0001;
+    this.dir.divideScalar(len);
+    this.quat.setFromUnitVectors(UP, this.dir);
+    this.mid.set((ax + bx) / 2, (ay + by) / 2, (az + bz) / 2);
+    const r = Math.max(0.04, (sim.radius[p] + sim.radius[node]) * 0.5);
+    this.dummy.position.copy(this.mid);
+    this.dummy.quaternion.copy(this.quat);
+    this.dummy.scale.set(r, len, r);
+    this.dummy.updateMatrix();
+    mesh.setMatrixAt(inst, this.dummy.matrix);
+  }
+
+  syncLeaves(sim: TreeSimulation, leafSize: number): void {
+    const sizeChanged = leafSize !== this.lastLeafSize;
+    const start = sizeChanged ? 0 : this.leafInst;
+    if (!sizeChanged && sim.leafCount === this.leafInst) return;
+    this.lastLeafSize = leafSize;
+    const color = new THREE.Color();
+    for (let i = start; i < sim.leafCount; i++) {
+      const node = sim.leafNode[i];
+      const seed = sim.leafSeed[i];
+      const ang = seed * Math.PI * 2;
+      const tilt = 0.5 + seed * 1.6;
+      const s = leafSize * (0.7 + 0.5 * seed);
+      // small offset so leaves don't all sit exactly on the branch tip
+      const off = 0.35;
+      this.dummy.position.set(
+        sim.px[node] + Math.cos(ang) * off,
+        sim.py[node] + (seed - 0.5) * 0.4,
+        sim.pz[node] + Math.sin(ang) * off
+      );
+      this.dummy.rotation.set(tilt, ang, seed * 0.8);
+      this.dummy.scale.setScalar(s);
+      this.dummy.updateMatrix();
+      this.leaves.setMatrixAt(i, this.dummy.matrix);
+      color.setHSL(0.27 + seed * 0.07, 0.55, 0.34 + seed * 0.16);
+      this.leaves.setColorAt(i, color);
+    }
+    this.leafInst = sim.leafCount;
+    this.leaves.count = sim.leafCount;
+    this.leaves.instanceMatrix.needsUpdate = true;
+    if (this.leaves.instanceColor) this.leaves.instanceColor.needsUpdate = true;
+  }
+
+  syncAttractors(sim: TreeSimulation, show: boolean): void {
+    this.canopyPoints.visible = show;
+    this.rootPoints.visible = show;
+    if (!show) return;
+    this.fillPoints(
+      this.canopyPoints,
+      sim.canopyX,
+      sim.canopyY,
+      sim.canopyZ,
+      sim.canopyAlive,
+      sim.canopyCount
+    );
+    this.fillPoints(
+      this.rootPoints,
+      sim.rootX,
+      sim.rootY,
+      sim.rootZ,
+      sim.rootAlive,
+      sim.rootAttrCount
+    );
+  }
+
+  private fillPoints(
+    pts: THREE.Points,
+    xs: Float32Array,
+    ys: Float32Array,
+    zs: Float32Array,
+    alive: Uint8Array,
+    count: number
+  ): void {
+    const attr = pts.geometry.getAttribute('position') as THREE.BufferAttribute;
+    const arr = attr.array as Float32Array;
+    let n = 0;
+    for (let i = 0; i < count; i++) {
+      if (!alive[i]) continue;
+      arr[n * 3] = xs[i];
+      arr[n * 3 + 1] = ys[i];
+      arr[n * 3 + 2] = zs[i];
+      n++;
+    }
+    pts.geometry.setDrawRange(0, n);
+    attr.needsUpdate = true;
+  }
+
+  applyParams(params: SimParams): void {
+    // sun direction follows the light toggle
+    if (params.lightDir === 'left') this.sun.position.set(-18, 16, 6);
+    else if (params.lightDir === 'right') this.sun.position.set(18, 16, 6);
+    else this.sun.position.set(4, 22, 8);
+
+    this.wind.uWind.value = params.wind;
+    this.leaves.visible = params.show.leaves;
+    this.roots.visible = params.show.roots;
+  }
+
+  setTime(t: number): void {
+    this.wind.uTime.value = t;
+  }
+
+  render(): void {
+    this.controls.update();
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  resize(): void {
+    const w = this.container.clientWidth || 1;
+    const h = this.container.clientHeight || 1;
+    this.camera.aspect = w / h;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(w, h);
+  }
+
+  dispose(): void {
+    this.controls.dispose();
+    this.branches.dispose();
+    this.roots.dispose();
+    this.leaves.dispose();
+    this.canopyPoints.geometry.dispose();
+    (this.canopyPoints.material as THREE.Material).dispose();
+    this.rootPoints.geometry.dispose();
+    (this.rootPoints.material as THREE.Material).dispose();
+    for (const d of this.disposables) d.dispose();
+    this.renderer.dispose();
+    if (this.renderer.domElement.parentElement === this.container) {
+      this.container.removeChild(this.renderer.domElement);
+    }
+  }
+}

--- a/src/studies/tree-growth/renderer.ts
+++ b/src/studies/tree-growth/renderer.ts
@@ -119,7 +119,7 @@ export class TreeRenderer {
 
     // --- branch / root / leaf meshes -------------------------------------
     const branchGeo = new THREE.CylinderGeometry(1, 1, 1, 6, 1);
-    const branchMat = this.makeWindMaterial(0x6b4a2f, 0.012, 0.85);
+    const branchMat = this.makeWindMaterial(0x6b4a2f, 0.012);
     this.branches = new THREE.InstancedMesh(branchGeo, branchMat, MAX_SHOOT_SEG);
     this.branches.count = 0;
     this.branches.frustumCulled = false;
@@ -127,7 +127,7 @@ export class TreeRenderer {
     this.disposables.push(branchGeo, branchMat);
 
     const rootGeo = new THREE.CylinderGeometry(1, 1, 1, 5, 1);
-    const rootMat = this.makeWindMaterial(0x7a5a3a, 0, 1);
+    const rootMat = this.makeWindMaterial(0x7a5a3a, 0);
     rootMat.transparent = true;
     rootMat.opacity = 0.92;
     this.roots = new THREE.InstancedMesh(rootGeo, rootMat, MAX_ROOT_SEG);
@@ -137,9 +137,8 @@ export class TreeRenderer {
     this.disposables.push(rootGeo, rootMat);
 
     const leafGeo = new THREE.CircleGeometry(0.5, 5);
-    const leafMat = this.makeWindMaterial(0x4e9a3d, 0.05, 1);
+    const leafMat = this.makeWindMaterial(0x4e9a3d, 0.05);
     leafMat.side = THREE.DoubleSide;
-    leafMat.roughness = 0.7;
     this.leaves = new THREE.InstancedMesh(leafGeo, leafMat, MAX_LEAVES);
     this.leaves.count = 0;
     this.leaves.frustumCulled = false;
@@ -159,14 +158,9 @@ export class TreeRenderer {
 
   private makeWindMaterial(
     color: number,
-    swayMul: number,
-    rough: number
-  ): THREE.MeshStandardMaterial {
-    const mat = new THREE.MeshStandardMaterial({
-      color,
-      roughness: rough,
-      metalness: 0,
-    });
+    swayMul: number
+  ): THREE.MeshLambertMaterial {
+    const mat = new THREE.MeshLambertMaterial({ color });
     mat.onBeforeCompile = (shader) => {
       shader.uniforms.uTime = this.wind.uTime;
       shader.uniforms.uWind = this.wind.uWind;

--- a/src/studies/tree-growth/simulation.ts
+++ b/src/studies/tree-growth/simulation.ts
@@ -40,24 +40,25 @@ const GRID_OFFSET = 512; // keeps cell indices non-negative
 
 // --- Resource economy ------------------------------------------------------
 const PHOTO_K = 16; // max carbon/sec at full leaf area
-const PHOTO_A = 0.0016; // photosynthesis saturation (self-shading)
+const PHOTO_A = 0.006; // photosynthesis saturation (self-shading)
 const UPT_K = 16; // max water/sec at full root mass
-const UPT_A = 0.0022; // uptake saturation
+const UPT_A = 0.006; // uptake saturation
 const RESERVE_CAP = 60;
-const START_RESERVE = 24; // bootstrap so the seedling can grow before it has leaves
+const START_RESERVE = 20; // bootstrap so the seedling can grow before it has leaves
 
 // carbon / water cost per new node (shoots are carbon-hungry, roots water-hungry)
-const COST_C_SHOOT = 0.9;
-const COST_W_SHOOT = 0.35;
-const COST_C_ROOT = 0.35;
-const COST_W_ROOT = 0.9;
+const COST_C_SHOOT = 0.45;
+const COST_W_SHOOT = 0.18;
+const COST_C_ROOT = 0.18;
+const COST_W_ROOT = 0.45;
 
 // growth pacing: space-colonization iterations per second at growthSpeed = 1
-const ITER_RATE = 7;
-const MAX_ITERS_PER_FRAME = 4;
+const ITER_RATE = 2.2;
+const MAX_ITERS_PER_FRAME = 3;
 
 const LEAF_MIN_DEPTH = 2;
 const LEAF_PROB = 0.85;
+const TRUNK_NODES = 3; // pre-grown starter trunk height (internodes)
 
 interface DirAcc {
   x: number;
@@ -146,8 +147,17 @@ export class TreeSimulation {
     const base = this.addNode(0, 0, 0, -1, KIND_SHOOT, 0);
     const rootBase = this.addNode(0, -0.3, 0, base, KIND_ROOT, 1);
     this.rootSeg++;
-    this.shootActive.push(base);
     this.rootActive.push(rootBase);
+
+    // pre-grow a short vertical trunk so the canopy growth front starts up
+    // among the light attractors (a bare seed at y=0 is out of their reach).
+    let prev = base;
+    for (let i = 1; i <= TRUNK_NODES; i++) {
+      const n = this.addNode(0, i * SEG_LEN, 0, prev, KIND_SHOOT, i);
+      this.shootSeg++;
+      prev = n;
+    }
+    this.shootActive.push(prev);
 
     this.seedAttractors(params);
     this.structureVersion++;
@@ -166,15 +176,15 @@ export class TreeSimulation {
     // canopy: an ellipsoid sitting above the ground
     this.canopyCount = canopyN;
     const cR = 10 + 2 * density;
-    const cYmin = 4;
+    const cYmin = 3.5;
     const cYmax = 24;
     for (let i = 0; i < canopyN; i++) {
       const [x, z] = diskSample(cR);
       const t = Math.cbrt(Math.random());
       this.canopyX[i] = x * t + (1 - t) * x * 0.4;
       this.canopyZ[i] = z * t + (1 - t) * z * 0.4;
-      const yt = Math.random();
-      this.canopyY[i] = cYmin + (cYmax - cYmin) * (0.2 + 0.8 * yt);
+      const yt = Math.pow(Math.random(), 0.85);
+      this.canopyY[i] = cYmin + (cYmax - cYmin) * yt;
       this.canopyAlive[i] = 1;
     }
 

--- a/src/studies/tree-growth/simulation.ts
+++ b/src/studies/tree-growth/simulation.ts
@@ -1,0 +1,508 @@
+/**
+ * TreeSimulation — framework-free growth model.
+ *
+ * Two coupled space-colonization systems grow simultaneously:
+ *   - the canopy grows toward "light" attractors above ground,
+ *   - the root system grows toward "nutrient" attractors below ground.
+ *
+ * Growth is gated by a small resource economy: leaves fix CARBON via
+ * photosynthesis, roots take up WATER/nutrients, and each new segment costs
+ * both. Whichever resource is scarce throttles growth and (under the default
+ * "balanced" allocation) biases investment toward the organ that captures it —
+ * the classic functional-equilibrium feedback loop.
+ *
+ * All state lives in preallocated typed arrays and the per-frame work is
+ * hard-capped, so the cost stays bounded no matter how large the tree gets.
+ */
+
+import {
+  MAX_ATTRACTORS,
+  MAX_LEAVES,
+  MAX_NODES,
+  Metrics,
+  SimParams,
+} from './types';
+
+const KIND_SHOOT = 0;
+const KIND_ROOT = 1;
+
+// --- Growth geometry -------------------------------------------------------
+const SEG_LEN = 1.3; // length of one internode
+const INFLUENCE = 7; // attractor influence radius (di)
+const KILL = 2.6; // attractor kill distance (dk)
+const CELL = INFLUENCE; // spatial-hash cell size
+const GRID_OFFSET = 512; // keeps cell indices non-negative
+
+// --- Resource economy ------------------------------------------------------
+const PHOTO_K = 16; // max carbon/sec at full leaf area
+const PHOTO_A = 0.0016; // photosynthesis saturation (self-shading)
+const UPT_K = 16; // max water/sec at full root mass
+const UPT_A = 0.0022; // uptake saturation
+const RESERVE_CAP = 60;
+const START_RESERVE = 22; // bootstrap so the seedling can grow before it has leaves
+
+// carbon / water cost per new node (shoots are carbon-hungry, roots water-hungry)
+const COST_C_SHOOT = 1.0;
+const COST_W_SHOOT = 0.4;
+const COST_C_ROOT = 0.4;
+const COST_W_ROOT = 1.0;
+
+const BASE_RATE = 58; // baseline nodes/sec at growthSpeed = 1
+const MAX_NODES_PER_FRAME = 34; // hard cap per organ per frame (anti-spike)
+const MAX_ITERS_PER_FRAME = 8;
+
+const LEAF_MIN_DEPTH = 3;
+const LEAF_PROB = 0.72;
+
+interface DirAcc {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export class TreeSimulation {
+  // node pool (shoots + roots share one pool, distinguished by `kind`)
+  readonly px = new Float32Array(MAX_NODES);
+  readonly py = new Float32Array(MAX_NODES);
+  readonly pz = new Float32Array(MAX_NODES);
+  readonly parent = new Int32Array(MAX_NODES);
+  readonly radius = new Float32Array(MAX_NODES);
+  readonly kind = new Uint8Array(MAX_NODES);
+  readonly isTip = new Uint8Array(MAX_NODES);
+  private readonly depth = new Int16Array(MAX_NODES);
+  private readonly subtreeTips = new Float32Array(MAX_NODES);
+  nodeCount = 0;
+
+  // leaves (reference into the node pool)
+  readonly leafNode = new Int32Array(MAX_LEAVES);
+  readonly leafSeed = new Float32Array(MAX_LEAVES);
+  leafCount = 0;
+
+  // attractor clouds
+  readonly canopyX = new Float32Array(MAX_ATTRACTORS);
+  readonly canopyY = new Float32Array(MAX_ATTRACTORS);
+  readonly canopyZ = new Float32Array(MAX_ATTRACTORS);
+  readonly canopyAlive = new Uint8Array(MAX_ATTRACTORS);
+  canopyCount = 0;
+  readonly rootX = new Float32Array(MAX_ATTRACTORS);
+  readonly rootY = new Float32Array(MAX_ATTRACTORS);
+  readonly rootZ = new Float32Array(MAX_ATTRACTORS);
+  readonly rootAlive = new Uint8Array(MAX_ATTRACTORS);
+  rootAttrCount = 0;
+
+  // growth fronts (small, active node indices)
+  private shootActive: number[] = [];
+  private rootActive: number[] = [];
+
+  // running counts
+  private shootSeg = 0;
+  private rootSeg = 0;
+
+  // resources
+  private carbon = START_RESERVE;
+  private water = START_RESERVE;
+  private production = 0;
+  private uptake = 0;
+
+  // dirty signalling for the renderer
+  structureVersion = 0;
+
+  private params: SimParams;
+  private grid = new Map<number, number[]>();
+
+  constructor(params: SimParams) {
+    this.params = params;
+    this.reset(params);
+  }
+
+  setParams(params: SimParams): void {
+    this.params = params;
+  }
+
+  /** Clear everything and re-seed the tree + attractor clouds. */
+  reset(params: SimParams): void {
+    this.params = params;
+    this.nodeCount = 0;
+    this.leafCount = 0;
+    this.shootSeg = 0;
+    this.rootSeg = 0;
+    this.shootActive = [];
+    this.rootActive = [];
+    this.carbon = START_RESERVE;
+    this.water = START_RESERVE;
+    this.production = 0;
+    this.uptake = 0;
+
+    // seed nodes: trunk base (shoot) + taproot base (root)
+    const base = this.addNode(0, 0, 0, -1, KIND_SHOOT, 0);
+    const rootBase = this.addNode(0, -0.3, 0, base, KIND_ROOT, 1);
+    this.rootSeg++;
+    this.shootActive.push(base);
+    this.rootActive.push(rootBase);
+
+    this.seedAttractors(params);
+    this.structureVersion++;
+  }
+
+  // ---------------------------------------------------------------- attractors
+  private seedAttractors(params: SimParams): void {
+    const density = params.branchDensity;
+    const canopyN = Math.min(MAX_ATTRACTORS, Math.round(900 * density));
+    const soilMul =
+      params.soil === 'poor' ? 0.55 : params.soil === 'rich' ? 1.4 : 1;
+    const rootN = Math.min(MAX_ATTRACTORS, Math.round(620 * density * soilMul));
+    const soilDepth =
+      params.soil === 'poor' ? 9 : params.soil === 'rich' ? 16 : 13;
+
+    // canopy: an ellipsoid sitting above the ground
+    this.canopyCount = canopyN;
+    const cR = 10 + 2 * density;
+    const cYmin = 5;
+    const cYmax = 25;
+    for (let i = 0; i < canopyN; i++) {
+      const [x, z] = diskSample(cR);
+      // bias points toward the upper-middle for a rounded crown
+      const t = Math.cbrt(Math.random());
+      this.canopyX[i] = x * t + (1 - t) * x * 0.4;
+      this.canopyZ[i] = z * t + (1 - t) * z * 0.4;
+      const yt = Math.random();
+      this.canopyY[i] = cYmin + (cYmax - cYmin) * (0.25 + 0.75 * yt);
+      this.canopyAlive[i] = 1;
+    }
+
+    // roots: a downward, outward-spreading cone of nutrient sites
+    this.rootAttrCount = rootN;
+    for (let i = 0; i < rootN; i++) {
+      const depth = Math.random();
+      const y = -0.8 - soilDepth * depth;
+      const spread = 3 + 8 * depth; // wider as it goes deeper
+      const [x, z] = diskSample(spread);
+      this.rootX[i] = x;
+      this.rootY[i] = y;
+      this.rootZ[i] = z;
+      this.rootAlive[i] = 1;
+    }
+  }
+
+  // ------------------------------------------------------------------ stepping
+  step(dt: number): void {
+    if (this.params.paused) return;
+    const p = this.params;
+
+    // 1. resource production / uptake (saturating curves)
+    const leafArea = this.leafCount * p.leafSize * p.leafSize;
+    this.production = p.sunlight * PHOTO_K * (1 - Math.exp(-PHOTO_A * leafArea));
+    const soilFactor =
+      p.soil === 'poor' ? 0.6 : p.soil === 'rich' ? 1.5 : 1;
+    this.uptake =
+      p.nutrients * soilFactor * UPT_K * (1 - Math.exp(-UPT_A * this.rootSeg));
+
+    this.carbon = Math.min(RESERVE_CAP, this.carbon + this.production * dt);
+    this.water = Math.min(RESERVE_CAP, this.water + this.uptake * dt);
+
+    // 2. growth pace (nodes attempted this frame) and shoot/root split
+    const pace = BASE_RATE * p.growthSpeed * dt;
+    const split = this.allocationSplit(p); // fraction to shoots
+    let shootTry = Math.round(pace * split);
+    let rootTry = Math.round(pace * (1 - split));
+
+    // 3. clamp by what the reserves can afford, then grow + deduct
+    shootTry = Math.min(
+      shootTry,
+      MAX_NODES_PER_FRAME,
+      Math.floor(this.carbon / COST_C_SHOOT),
+      Math.floor(this.water / COST_W_SHOOT)
+    );
+    rootTry = Math.min(
+      rootTry,
+      MAX_NODES_PER_FRAME,
+      Math.floor(this.carbon / COST_C_ROOT),
+      Math.floor(this.water / COST_W_ROOT)
+    );
+
+    const grownShoot = this.growKind(KIND_SHOOT, Math.max(0, shootTry));
+    const grownRoot = this.growKind(KIND_ROOT, Math.max(0, rootTry));
+
+    this.carbon -= grownShoot * COST_C_SHOOT + grownRoot * COST_C_ROOT;
+    this.water -= grownShoot * COST_W_SHOOT + grownRoot * COST_W_ROOT;
+    this.carbon = Math.max(0, this.carbon);
+    this.water = Math.max(0, this.water);
+
+    if (grownShoot + grownRoot > 0) this.structureVersion++;
+  }
+
+  /** Fraction of growth budget that should go to shoots. */
+  private allocationSplit(p: SimParams): number {
+    if (p.allocation === 'shoots') return 0.82;
+    if (p.allocation === 'roots') return 0.18;
+    // balanced → functional equilibrium: invest in the organ that gathers the
+    // scarce resource. Carbon-limited → grow shoots (more leaves); water-limited
+    // → grow roots.
+    const cRatio = this.carbon / RESERVE_CAP;
+    const wRatio = this.water / RESERVE_CAP;
+    const total = cRatio + wRatio || 1;
+    // when carbon is scarce relative to water, push shoots, and vice-versa
+    const shootBias = wRatio / total; // low carbon → wRatio dominates → more shoots
+    return 0.3 + 0.4 * shootBias; // keep within [0.3, 0.7] for stability
+  }
+
+  private growKind(kind: number, budget: number): number {
+    if (budget <= 0) return 0;
+    const active = kind === KIND_ROOT ? this.rootActive : this.shootActive;
+    if (active.length === 0) return 0;
+
+    let added = 0;
+    let iter = 0;
+    let current = active;
+
+    while (added < budget && iter < MAX_ITERS_PER_FRAME) {
+      this.buildGrid(current);
+
+      // accumulate attractor pull per active node
+      const infl = new Map<number, DirAcc>();
+      const n = kind === KIND_ROOT ? this.rootAttrCount : this.canopyCount;
+      const ax = kind === KIND_ROOT ? this.rootX : this.canopyX;
+      const ay = kind === KIND_ROOT ? this.rootY : this.canopyY;
+      const az = kind === KIND_ROOT ? this.rootZ : this.canopyZ;
+      const alive = kind === KIND_ROOT ? this.rootAlive : this.canopyAlive;
+
+      for (let i = 0; i < n; i++) {
+        if (!alive[i]) continue;
+        const near = this.nearest(ax[i], ay[i], az[i], INFLUENCE);
+        if (near < 0) continue;
+        let dx = ax[i] - this.px[near];
+        let dy = ay[i] - this.py[near];
+        let dz = az[i] - this.pz[near];
+        const len = Math.hypot(dx, dy, dz) || 1;
+        dx /= len;
+        dy /= len;
+        dz /= len;
+        const acc = infl.get(near);
+        if (acc) {
+          acc.x += dx;
+          acc.y += dy;
+          acc.z += dz;
+        } else {
+          infl.set(near, { x: dx, y: dy, z: dz });
+        }
+      }
+
+      if (infl.size === 0) break;
+
+      const next: number[] = [];
+      const seen = new Set<number>();
+      for (const [idx, acc] of infl) {
+        if (added >= budget) {
+          if (!seen.has(idx)) {
+            seen.add(idx);
+            next.push(idx); // defer to next frame
+          }
+          continue;
+        }
+        // blend attractor direction with a tropism bias
+        let dx = acc.x;
+        let dy = acc.y;
+        let dz = acc.z;
+        this.applyTropism(kind, idx, (bx, by, bz) => {
+          dx += bx;
+          dy += by;
+          dz += bz;
+        });
+        const len = Math.hypot(dx, dy, dz) || 1;
+        const nx = this.px[idx] + (dx / len) * SEG_LEN;
+        const ny = this.py[idx] + (dy / len) * SEG_LEN;
+        const nz = this.pz[idx] + (dz / len) * SEG_LEN;
+
+        const child = this.addNode(nx, ny, nz, idx, kind, this.depth[idx] + 1);
+        if (child < 0) break; // node pool full
+        if (kind === KIND_ROOT) this.rootSeg++;
+        else this.shootSeg++;
+
+        // leaves only on the canopy, above a minimum depth
+        if (
+          kind === KIND_SHOOT &&
+          this.depth[child] >= LEAF_MIN_DEPTH &&
+          Math.random() < LEAF_PROB
+        ) {
+          this.addLeaf(child);
+        }
+
+        added++;
+        if (!seen.has(idx)) {
+          seen.add(idx);
+          next.push(idx); // parent may keep branching
+        }
+        next.push(child);
+      }
+
+      // prune attractors reached by the (updated) front
+      this.buildGrid(next);
+      this.pruneAttractors(kind);
+
+      current = next;
+      iter++;
+    }
+
+    if (kind === KIND_ROOT) this.rootActive = current;
+    else this.shootActive = current;
+    return added;
+  }
+
+  private applyTropism(
+    kind: number,
+    _idx: number,
+    add: (x: number, y: number, z: number) => void
+  ): void {
+    if (kind === KIND_ROOT) {
+      add(0, -0.55, 0); // gravitropism: roots head down
+      return;
+    }
+    // canopy: phototropism (up + horizontal toward the light)
+    add(0, 0.35, 0);
+    const dir = this.params.lightDir;
+    if (dir === 'left') add(-0.4, 0.1, 0);
+    else if (dir === 'right') add(0.4, 0.1, 0);
+  }
+
+  // --------------------------------------------------------------------- nodes
+  private addNode(
+    x: number,
+    y: number,
+    z: number,
+    parent: number,
+    kind: number,
+    depth: number
+  ): number {
+    if (this.nodeCount >= MAX_NODES) return -1;
+    const i = this.nodeCount++;
+    this.px[i] = x;
+    this.py[i] = y;
+    this.pz[i] = z;
+    this.parent[i] = parent;
+    this.kind[i] = kind;
+    this.depth[i] = depth;
+    this.isTip[i] = 1;
+    this.radius[i] = 0.08;
+    if (parent >= 0) this.isTip[parent] = 0;
+    return i;
+  }
+
+  private addLeaf(node: number): void {
+    if (this.leafCount >= MAX_LEAVES) return;
+    const i = this.leafCount++;
+    this.leafNode[i] = node;
+    this.leafSeed[i] = Math.random();
+  }
+
+  /**
+   * Pipe model: a node's radius scales with the number of tip descendants it
+   * supports. Recomputed on a throttle by the render loop (only when the
+   * structure changed), so it never runs every frame.
+   */
+  refreshTaper(): void {
+    const n = this.nodeCount;
+    for (let i = 0; i < n; i++) this.subtreeTips[i] = this.isTip[i] ? 1 : 0;
+    // children are always created after their parent → reverse pass accumulates
+    for (let i = n - 1; i >= 1; i--) {
+      const par = this.parent[i];
+      if (par >= 0) this.subtreeTips[par] += this.subtreeTips[i];
+    }
+    for (let i = 0; i < n; i++) {
+      const tips = this.subtreeTips[i];
+      const r = 0.07 * Math.pow(tips, 1 / 2.3);
+      this.radius[i] = Math.min(1.6, Math.max(0.05, r));
+    }
+  }
+
+  // ------------------------------------------------------------- spatial hash
+  private buildGrid(nodes: number[]): void {
+    this.grid.clear();
+    for (let k = 0; k < nodes.length; k++) {
+      const idx = nodes[k];
+      const key = this.cellKey(this.px[idx], this.py[idx], this.pz[idx]);
+      const bucket = this.grid.get(key);
+      if (bucket) bucket.push(idx);
+      else this.grid.set(key, [idx]);
+    }
+  }
+
+  private cellKey(x: number, y: number, z: number): number {
+    const ix = Math.floor(x / CELL) + GRID_OFFSET;
+    const iy = Math.floor(y / CELL) + GRID_OFFSET;
+    const iz = Math.floor(z / CELL) + GRID_OFFSET;
+    return ix | (iy << 10) | (iz << 20);
+  }
+
+  private nearest(x: number, y: number, z: number, maxR: number): number {
+    const ix = Math.floor(x / CELL) + GRID_OFFSET;
+    const iy = Math.floor(y / CELL) + GRID_OFFSET;
+    const iz = Math.floor(z / CELL) + GRID_OFFSET;
+    let best = -1;
+    let bestD2 = maxR * maxR;
+    for (let dx = -1; dx <= 1; dx++) {
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dz = -1; dz <= 1; dz++) {
+          const key =
+            (ix + dx) | ((iy + dy) << 10) | ((iz + dz) << 20);
+          const bucket = this.grid.get(key);
+          if (!bucket) continue;
+          for (let b = 0; b < bucket.length; b++) {
+            const idx = bucket[b];
+            const ex = x - this.px[idx];
+            const ey = y - this.py[idx];
+            const ez = z - this.pz[idx];
+            const d2 = ex * ex + ey * ey + ez * ez;
+            if (d2 < bestD2) {
+              bestD2 = d2;
+              best = idx;
+            }
+          }
+        }
+      }
+    }
+    return best;
+  }
+
+  private pruneAttractors(kind: number): void {
+    const n = kind === KIND_ROOT ? this.rootAttrCount : this.canopyCount;
+    const ax = kind === KIND_ROOT ? this.rootX : this.canopyX;
+    const ay = kind === KIND_ROOT ? this.rootY : this.canopyY;
+    const az = kind === KIND_ROOT ? this.rootZ : this.canopyZ;
+    const alive = kind === KIND_ROOT ? this.rootAlive : this.canopyAlive;
+    for (let i = 0; i < n; i++) {
+      if (!alive[i]) continue;
+      const near = this.nearest(ax[i], ay[i], az[i], KILL);
+      if (near >= 0) alive[i] = 0;
+    }
+  }
+
+  // ------------------------------------------------------------------ metrics
+  getMetrics(fps: number): Metrics {
+    const cRatio = this.carbon / RESERVE_CAP;
+    const wRatio = this.water / RESERVE_CAP;
+    let limiting: Metrics['limiting'] = 'balanced';
+    if (cRatio < 0.6 || wRatio < 0.6) {
+      limiting = cRatio <= wRatio ? 'carbon' : 'water';
+    }
+    return {
+      production: this.production,
+      uptake: this.uptake,
+      carbon: this.carbon,
+      water: this.water,
+      carbonCap: RESERVE_CAP,
+      waterCap: RESERVE_CAP,
+      limiting,
+      branches: this.shootSeg,
+      leaves: this.leafCount,
+      roots: this.rootSeg,
+      fps,
+    };
+  }
+}
+
+/** Uniform sample inside a disk of the given radius. Returns [x, z]. */
+function diskSample(radius: number): [number, number] {
+  const r = radius * Math.sqrt(Math.random());
+  const a = Math.random() * Math.PI * 2;
+  return [r * Math.cos(a), r * Math.sin(a)];
+}

--- a/src/studies/tree-growth/simulation.ts
+++ b/src/studies/tree-growth/simulation.ts
@@ -11,6 +11,11 @@
  * "balanced" allocation) biases investment toward the organ that captures it —
  * the classic functional-equilibrium feedback loop.
  *
+ * Growth advances in discrete space-colonization *iterations* paced by a growth
+ * clock: each iteration pushes the whole active growth front forward by one
+ * internode (so depth, and therefore leaves and photosynthesis, ramps up
+ * quickly), while resource affordability caps how much of the front can grow.
+ *
  * All state lives in preallocated typed arrays and the per-frame work is
  * hard-capped, so the cost stays bounded no matter how large the tree gets.
  */
@@ -39,20 +44,20 @@ const PHOTO_A = 0.0016; // photosynthesis saturation (self-shading)
 const UPT_K = 16; // max water/sec at full root mass
 const UPT_A = 0.0022; // uptake saturation
 const RESERVE_CAP = 60;
-const START_RESERVE = 22; // bootstrap so the seedling can grow before it has leaves
+const START_RESERVE = 24; // bootstrap so the seedling can grow before it has leaves
 
 // carbon / water cost per new node (shoots are carbon-hungry, roots water-hungry)
-const COST_C_SHOOT = 1.0;
-const COST_W_SHOOT = 0.4;
-const COST_C_ROOT = 0.4;
-const COST_W_ROOT = 1.0;
+const COST_C_SHOOT = 0.9;
+const COST_W_SHOOT = 0.35;
+const COST_C_ROOT = 0.35;
+const COST_W_ROOT = 0.9;
 
-const BASE_RATE = 58; // baseline nodes/sec at growthSpeed = 1
-const MAX_NODES_PER_FRAME = 34; // hard cap per organ per frame (anti-spike)
-const MAX_ITERS_PER_FRAME = 8;
+// growth pacing: space-colonization iterations per second at growthSpeed = 1
+const ITER_RATE = 7;
+const MAX_ITERS_PER_FRAME = 4;
 
-const LEAF_MIN_DEPTH = 3;
-const LEAF_PROB = 0.72;
+const LEAF_MIN_DEPTH = 2;
+const LEAF_PROB = 0.85;
 
 interface DirAcc {
   x: number;
@@ -93,6 +98,8 @@ export class TreeSimulation {
   // growth fronts (small, active node indices)
   private shootActive: number[] = [];
   private rootActive: number[] = [];
+  private shootClock = 0;
+  private rootClock = 0;
 
   // running counts
   private shootSeg = 0;
@@ -128,6 +135,8 @@ export class TreeSimulation {
     this.rootSeg = 0;
     this.shootActive = [];
     this.rootActive = [];
+    this.shootClock = 0;
+    this.rootClock = 0;
     this.carbon = START_RESERVE;
     this.water = START_RESERVE;
     this.production = 0;
@@ -157,25 +166,24 @@ export class TreeSimulation {
     // canopy: an ellipsoid sitting above the ground
     this.canopyCount = canopyN;
     const cR = 10 + 2 * density;
-    const cYmin = 5;
-    const cYmax = 25;
+    const cYmin = 4;
+    const cYmax = 24;
     for (let i = 0; i < canopyN; i++) {
       const [x, z] = diskSample(cR);
-      // bias points toward the upper-middle for a rounded crown
       const t = Math.cbrt(Math.random());
       this.canopyX[i] = x * t + (1 - t) * x * 0.4;
       this.canopyZ[i] = z * t + (1 - t) * z * 0.4;
       const yt = Math.random();
-      this.canopyY[i] = cYmin + (cYmax - cYmin) * (0.25 + 0.75 * yt);
+      this.canopyY[i] = cYmin + (cYmax - cYmin) * (0.2 + 0.8 * yt);
       this.canopyAlive[i] = 1;
     }
 
     // roots: a downward, outward-spreading cone of nutrient sites
     this.rootAttrCount = rootN;
     for (let i = 0; i < rootN; i++) {
-      const depth = Math.random();
-      const y = -0.8 - soilDepth * depth;
-      const spread = 3 + 8 * depth; // wider as it goes deeper
+      const d = Math.random();
+      const y = -0.8 - soilDepth * d;
+      const spread = 3 + 8 * d;
       const [x, z] = diskSample(spread);
       this.rootX[i] = x;
       this.rootY[i] = y;
@@ -192,43 +200,41 @@ export class TreeSimulation {
     // 1. resource production / uptake (saturating curves)
     const leafArea = this.leafCount * p.leafSize * p.leafSize;
     this.production = p.sunlight * PHOTO_K * (1 - Math.exp(-PHOTO_A * leafArea));
-    const soilFactor =
-      p.soil === 'poor' ? 0.6 : p.soil === 'rich' ? 1.5 : 1;
+    const soilFactor = p.soil === 'poor' ? 0.6 : p.soil === 'rich' ? 1.5 : 1;
     this.uptake =
       p.nutrients * soilFactor * UPT_K * (1 - Math.exp(-UPT_A * this.rootSeg));
 
     this.carbon = Math.min(RESERVE_CAP, this.carbon + this.production * dt);
     this.water = Math.min(RESERVE_CAP, this.water + this.uptake * dt);
 
-    // 2. growth pace (nodes attempted this frame) and shoot/root split
-    const pace = BASE_RATE * p.growthSpeed * dt;
-    const split = this.allocationSplit(p); // fraction to shoots
-    let shootTry = Math.round(pace * split);
-    let rootTry = Math.round(pace * (1 - split));
+    // 2. advance growth clocks (iterations are biased by the allocation split)
+    const split = this.allocationSplit(p);
+    const rate = dt * p.growthSpeed * ITER_RATE;
+    this.shootClock += rate * 2 * split;
+    this.rootClock += rate * 2 * (1 - split);
 
-    // 3. clamp by what the reserves can afford, then grow + deduct
-    shootTry = Math.min(
-      shootTry,
-      MAX_NODES_PER_FRAME,
-      Math.floor(this.carbon / COST_C_SHOOT),
-      Math.floor(this.water / COST_W_SHOOT)
-    );
-    rootTry = Math.min(
-      rootTry,
-      MAX_NODES_PER_FRAME,
-      Math.floor(this.carbon / COST_C_ROOT),
-      Math.floor(this.water / COST_W_ROOT)
-    );
+    // 3. run paced space-colonization iterations (resource-gated inside)
+    let grew = false;
+    let iters = 0;
+    while (
+      iters < MAX_ITERS_PER_FRAME &&
+      (this.shootClock >= 1 || this.rootClock >= 1)
+    ) {
+      if (this.shootClock >= 1) {
+        this.shootClock -= 1;
+        if (this.runIteration(KIND_SHOOT)) grew = true;
+      }
+      if (this.rootClock >= 1) {
+        this.rootClock -= 1;
+        if (this.runIteration(KIND_ROOT)) grew = true;
+      }
+      iters++;
+    }
+    // avoid clock build-up while resource-starved
+    if (this.shootClock > 2) this.shootClock = 2;
+    if (this.rootClock > 2) this.rootClock = 2;
 
-    const grownShoot = this.growKind(KIND_SHOOT, Math.max(0, shootTry));
-    const grownRoot = this.growKind(KIND_ROOT, Math.max(0, rootTry));
-
-    this.carbon -= grownShoot * COST_C_SHOOT + grownRoot * COST_C_ROOT;
-    this.water -= grownShoot * COST_W_SHOOT + grownRoot * COST_W_ROOT;
-    this.carbon = Math.max(0, this.carbon);
-    this.water = Math.max(0, this.water);
-
-    if (grownShoot + grownRoot > 0) this.structureVersion++;
+    if (grew) this.structureVersion++;
   }
 
   /** Fraction of growth budget that should go to shoots. */
@@ -236,121 +242,111 @@ export class TreeSimulation {
     if (p.allocation === 'shoots') return 0.82;
     if (p.allocation === 'roots') return 0.18;
     // balanced → functional equilibrium: invest in the organ that gathers the
-    // scarce resource. Carbon-limited → grow shoots (more leaves); water-limited
+    // scarce resource. Carbon scarce → grow shoots (more leaves); water scarce
     // → grow roots.
     const cRatio = this.carbon / RESERVE_CAP;
     const wRatio = this.water / RESERVE_CAP;
     const total = cRatio + wRatio || 1;
-    // when carbon is scarce relative to water, push shoots, and vice-versa
     const shootBias = wRatio / total; // low carbon → wRatio dominates → more shoots
-    return 0.3 + 0.4 * shootBias; // keep within [0.3, 0.7] for stability
+    return 0.32 + 0.36 * shootBias; // clamp to a stable [0.32, 0.68] band
   }
 
-  private growKind(kind: number, budget: number): number {
-    if (budget <= 0) return 0;
+  /**
+   * One space-colonization iteration for the given organ: every active node
+   * that is pulled by a live attractor spawns one child toward the average
+   * attractor direction (plus a tropism bias), provided the reserves can pay
+   * for it. Returns true if at least one node was added.
+   */
+  private runIteration(kind: number): boolean {
     const active = kind === KIND_ROOT ? this.rootActive : this.shootActive;
-    if (active.length === 0) return 0;
+    if (active.length === 0) return false;
 
-    let added = 0;
-    let iter = 0;
-    let current = active;
+    this.buildGrid(active);
 
-    while (added < budget && iter < MAX_ITERS_PER_FRAME) {
-      this.buildGrid(current);
+    const n = kind === KIND_ROOT ? this.rootAttrCount : this.canopyCount;
+    const ax = kind === KIND_ROOT ? this.rootX : this.canopyX;
+    const ay = kind === KIND_ROOT ? this.rootY : this.canopyY;
+    const az = kind === KIND_ROOT ? this.rootZ : this.canopyZ;
+    const alive = kind === KIND_ROOT ? this.rootAlive : this.canopyAlive;
 
-      // accumulate attractor pull per active node
-      const infl = new Map<number, DirAcc>();
-      const n = kind === KIND_ROOT ? this.rootAttrCount : this.canopyCount;
-      const ax = kind === KIND_ROOT ? this.rootX : this.canopyX;
-      const ay = kind === KIND_ROOT ? this.rootY : this.canopyY;
-      const az = kind === KIND_ROOT ? this.rootZ : this.canopyZ;
-      const alive = kind === KIND_ROOT ? this.rootAlive : this.canopyAlive;
-
-      for (let i = 0; i < n; i++) {
-        if (!alive[i]) continue;
-        const near = this.nearest(ax[i], ay[i], az[i], INFLUENCE);
-        if (near < 0) continue;
-        let dx = ax[i] - this.px[near];
-        let dy = ay[i] - this.py[near];
-        let dz = az[i] - this.pz[near];
-        const len = Math.hypot(dx, dy, dz) || 1;
-        dx /= len;
-        dy /= len;
-        dz /= len;
-        const acc = infl.get(near);
-        if (acc) {
-          acc.x += dx;
-          acc.y += dy;
-          acc.z += dz;
-        } else {
-          infl.set(near, { x: dx, y: dy, z: dz });
-        }
+    const infl = new Map<number, DirAcc>();
+    for (let i = 0; i < n; i++) {
+      if (!alive[i]) continue;
+      const near = this.nearest(ax[i], ay[i], az[i], INFLUENCE);
+      if (near < 0) continue;
+      let dx = ax[i] - this.px[near];
+      let dy = ay[i] - this.py[near];
+      let dz = az[i] - this.pz[near];
+      const len = Math.hypot(dx, dy, dz) || 1;
+      dx /= len;
+      dy /= len;
+      dz /= len;
+      const acc = infl.get(near);
+      if (acc) {
+        acc.x += dx;
+        acc.y += dy;
+        acc.z += dz;
+      } else {
+        infl.set(near, { x: dx, y: dy, z: dz });
       }
-
-      if (infl.size === 0) break;
-
-      const next: number[] = [];
-      const seen = new Set<number>();
-      for (const [idx, acc] of infl) {
-        if (added >= budget) {
-          if (!seen.has(idx)) {
-            seen.add(idx);
-            next.push(idx); // defer to next frame
-          }
-          continue;
-        }
-        // blend attractor direction with a tropism bias
-        let dx = acc.x;
-        let dy = acc.y;
-        let dz = acc.z;
-        this.applyTropism(kind, idx, (bx, by, bz) => {
-          dx += bx;
-          dy += by;
-          dz += bz;
-        });
-        const len = Math.hypot(dx, dy, dz) || 1;
-        const nx = this.px[idx] + (dx / len) * SEG_LEN;
-        const ny = this.py[idx] + (dy / len) * SEG_LEN;
-        const nz = this.pz[idx] + (dz / len) * SEG_LEN;
-
-        const child = this.addNode(nx, ny, nz, idx, kind, this.depth[idx] + 1);
-        if (child < 0) break; // node pool full
-        if (kind === KIND_ROOT) this.rootSeg++;
-        else this.shootSeg++;
-
-        // leaves only on the canopy, above a minimum depth
-        if (
-          kind === KIND_SHOOT &&
-          this.depth[child] >= LEAF_MIN_DEPTH &&
-          Math.random() < LEAF_PROB
-        ) {
-          this.addLeaf(child);
-        }
-
-        added++;
-        if (!seen.has(idx)) {
-          seen.add(idx);
-          next.push(idx); // parent may keep branching
-        }
-        next.push(child);
-      }
-
-      // prune attractors reached by the (updated) front
-      this.buildGrid(next);
-      this.pruneAttractors(kind);
-
-      current = next;
-      iter++;
     }
 
-    if (kind === KIND_ROOT) this.rootActive = current;
-    else this.shootActive = current;
-    return added;
+    if (infl.size === 0) return false;
+
+    const costC = kind === KIND_ROOT ? COST_C_ROOT : COST_C_SHOOT;
+    const costW = kind === KIND_ROOT ? COST_W_ROOT : COST_W_SHOOT;
+
+    const next: number[] = [];
+    const seen = new Set<number>();
+    let added = 0;
+    for (const [idx, acc] of infl) {
+      seen.add(idx);
+      next.push(idx); // keep the parent on the front so it can branch
+      // resource gate: stop growing this organ once it can't pay
+      if (this.carbon < costC || this.water < costW) continue;
+
+      let dx = acc.x;
+      let dy = acc.y;
+      let dz = acc.z;
+      this.applyTropism(kind, (bx, by, bz) => {
+        dx += bx;
+        dy += by;
+        dz += bz;
+      });
+      const len = Math.hypot(dx, dy, dz) || 1;
+      const nx = this.px[idx] + (dx / len) * SEG_LEN;
+      const ny = this.py[idx] + (dy / len) * SEG_LEN;
+      const nz = this.pz[idx] + (dz / len) * SEG_LEN;
+
+      const child = this.addNode(nx, ny, nz, idx, kind, this.depth[idx] + 1);
+      if (child < 0) break; // node pool full
+      if (kind === KIND_ROOT) this.rootSeg++;
+      else this.shootSeg++;
+      this.carbon -= costC;
+      this.water -= costW;
+      added++;
+
+      if (
+        kind === KIND_SHOOT &&
+        this.depth[child] >= LEAF_MIN_DEPTH &&
+        Math.random() < LEAF_PROB
+      ) {
+        this.addLeaf(child);
+      }
+      next.push(child);
+    }
+
+    // prune attractors reached by the advanced front, then retire dead nodes
+    this.buildGrid(next);
+    this.pruneAttractors(kind);
+
+    if (kind === KIND_ROOT) this.rootActive = next;
+    else this.shootActive = next;
+    return added > 0;
   }
 
   private applyTropism(
     kind: number,
-    _idx: number,
     add: (x: number, y: number, z: number) => void
   ): void {
     if (kind === KIND_ROOT) {
@@ -360,8 +356,8 @@ export class TreeSimulation {
     // canopy: phototropism (up + horizontal toward the light)
     add(0, 0.35, 0);
     const dir = this.params.lightDir;
-    if (dir === 'left') add(-0.4, 0.1, 0);
-    else if (dir === 'right') add(0.4, 0.1, 0);
+    if (dir === 'left') add(-0.45, 0.1, 0);
+    else if (dir === 'right') add(0.45, 0.1, 0);
   }
 
   // --------------------------------------------------------------------- nodes
@@ -442,8 +438,7 @@ export class TreeSimulation {
     for (let dx = -1; dx <= 1; dx++) {
       for (let dy = -1; dy <= 1; dy++) {
         for (let dz = -1; dz <= 1; dz++) {
-          const key =
-            (ix + dx) | ((iy + dy) << 10) | ((iz + dz) << 20);
+          const key = (ix + dx) | ((iy + dy) << 10) | ((iz + dz) << 20);
           const bucket = this.grid.get(key);
           if (!bucket) continue;
           for (let b = 0; b < bucket.length; b++) {

--- a/src/studies/tree-growth/simulation.ts
+++ b/src/studies/tree-growth/simulation.ts
@@ -483,11 +483,16 @@ export class TreeSimulation {
 
   // ------------------------------------------------------------------ metrics
   getMetrics(fps: number): Metrics {
-    const cRatio = this.carbon / RESERVE_CAP;
-    const wRatio = this.water / RESERVE_CAP;
+    // availability blends the stored reserve with the current supply rate, so
+    // the readout reflects what the grower is tweaking even on a mature tree
+    // whose pools happen to be full.
+    const carbonAvail =
+      0.5 * (this.carbon / RESERVE_CAP) + 0.5 * (this.production / PHOTO_K);
+    const waterAvail =
+      0.5 * (this.water / RESERVE_CAP) + 0.5 * (this.uptake / UPT_K);
     let limiting: Metrics['limiting'] = 'balanced';
-    if (cRatio < 0.6 || wRatio < 0.6) {
-      limiting = cRatio <= wRatio ? 'carbon' : 'water';
+    if (Math.abs(carbonAvail - waterAvail) > 0.2) {
+      limiting = carbonAvail < waterAvail ? 'carbon' : 'water';
     }
     return {
       production: this.production,

--- a/src/studies/tree-growth/types.ts
+++ b/src/studies/tree-growth/types.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared types, defaults, and hard caps for the real-time growth tree simulation.
+ *
+ * The caps below bound both memory (preallocated typed arrays + instance buffers)
+ * and per-frame work, which is what keeps the simulation reliably performant even
+ * once the tree has fully matured.
+ */
+
+export type Allocation = 'balanced' | 'shoots' | 'roots';
+export type LightDir = 'left' | 'top' | 'right';
+export type Soil = 'poor' | 'normal' | 'rich';
+
+export interface DisplayLayers {
+  leaves: boolean;
+  roots: boolean;
+  attractors: boolean;
+}
+
+/** All live-tunable simulation parameters, owned by the React UI. */
+export interface SimParams {
+  /** Drives photosynthesis (carbon production) and thus canopy growth. */
+  sunlight: number;
+  /** Drives water/nutrient uptake and thus root growth. */
+  nutrients: number;
+  /** Global growth-rate multiplier. */
+  growthSpeed: number;
+  /** Attractor density — controls bushiness (structural: triggers a regrow). */
+  branchDensity: number;
+  /** Procedural wind sway amplitude (purely visual, GPU-side). */
+  wind: number;
+  /** Leaf scale; also lightly affects effective leaf area for photosynthesis. */
+  leafSize: number;
+  /** Growth-allocation override (or 'balanced' for functional equilibrium). */
+  allocation: Allocation;
+  /** Sun direction + canopy tropism bias. */
+  lightDir: LightDir;
+  /** Soil nutrient profile (structural: triggers a regrow). */
+  soil: Soil;
+  /** Per-layer visibility toggles. */
+  show: DisplayLayers;
+  /** When true, growth is frozen (rendering + wind continue). */
+  paused: boolean;
+}
+
+export const DEFAULT_PARAMS: SimParams = {
+  sunlight: 1,
+  nutrients: 1,
+  growthSpeed: 1,
+  branchDensity: 1,
+  wind: 0.35,
+  leafSize: 1,
+  allocation: 'balanced',
+  lightDir: 'top',
+  soil: 'normal',
+  show: { leaves: true, roots: true, attractors: false },
+  paused: false,
+};
+
+export type LimitingFactor = 'carbon' | 'water' | 'balanced';
+
+/** Live readouts surfaced to the feedback panel (throttled, not per-frame). */
+export interface Metrics {
+  /** Carbon produced per second by photosynthesis. */
+  production: number;
+  /** Water/nutrients taken up per second by the roots. */
+  uptake: number;
+  /** Current stored carbon reserve. */
+  carbon: number;
+  /** Current stored water reserve. */
+  water: number;
+  /** Reserve capacities (for bar normalization). */
+  carbonCap: number;
+  waterCap: number;
+  /** Which resource is currently constraining growth. */
+  limiting: LimitingFactor;
+  /** Structural counts. */
+  branches: number;
+  leaves: number;
+  roots: number;
+  /** Rendering frame rate. */
+  fps: number;
+}
+
+export const EMPTY_METRICS: Metrics = {
+  production: 0,
+  uptake: 0,
+  carbon: 0,
+  water: 0,
+  carbonCap: 1,
+  waterCap: 1,
+  limiting: 'balanced',
+  branches: 0,
+  leaves: 0,
+  roots: 0,
+  fps: 0,
+};
+
+/**
+ * Hard caps. Nodes are stored in a single pool shared by shoots and roots.
+ * Each non-seed node contributes exactly one rendered segment.
+ */
+export const MAX_NODES = 14000;
+export const MAX_SHOOT_SEG = 8000;
+export const MAX_ROOT_SEG = 6000;
+export const MAX_LEAVES = 4000;
+export const MAX_ATTRACTORS = 2200; // per cloud (canopy + roots)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new interactive study, **Growth Tree** — a real-time, GPU-accelerated 3D simulation of a tree growing *both* its canopy and its **root system**, driven by a small botanical **resource economy**. Leaves fix **carbon** via photosynthesis, roots take up **water/nutrients**, and growth is gated by whichever resource is limiting — the classic functional-equilibrium feedback loop. The sidebar exposes a minimal set of high-impact sliders + button toggle groups, plus a live **Resource flux** panel showing production and uptake rates.

This also resolves the long-standing `// TODO: make this dynamic based on the set of studies` in `App.tsx` by adding a study registry + a sidebar **study switcher** (L-Systems remains accessible).

<a href="https://cursor.com/agents/bc-014657ab-6604-4789-8ada-f830992d139b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgrowth-tree-simulation-demo.mp4"><img src="https://cursor.com/artifacts/c/art-a92e5af3-f513-4635-bd99-cae0a2cbf786" alt="growth-tree-simulation-demo.mp4" /></a>

## How it works

- **Dual space colonization** (Runions et al.): the canopy grows toward "light" attractors above ground; the root system grows toward "nutrient" attractors below ground. Growth advances as paced space-colonization *iterations* so the whole growth front moves forward (depth → leaves → photosynthesis ramps up quickly).
- **Resource economy:** saturating photosynthesis (leaves × sunlight) and nutrient uptake (root mass × soil nutrients) feed carbon/water reserves; each new segment costs both. Under the default *Balanced* allocation the plant invests in the organ that captures the scarce resource (carbon-scarce → shoots, water-scarce → roots).
- **Pipe-model tapering** for natural trunk/branch thickness.
- **Procedural GPU wind** via a vertex-shader displacement (single `uTime` uniform) — no physics dependency.

> **Rapier:** intentionally not used. Rigid-body-per-branch physics for thousands of branches conflicts with the performance goal; procedural GPU wind achieves the motion cheaply.

## UI (minimal, high-impact)

- **Sliders:** Sunlight, Soil Nutrients, Growth Speed, Branch Density, Wind, Leaf Size.
- **Button toggle groups:** Allocation (Balanced/Shoots/Roots), Light Direction, Soil (Poor/Normal/Rich), Show layers (Leaves/Roots/Sites).
- **Buttons:** Replant, Pause/Resume.
- **Resource flux panel:** live Photosynthesis (carbon) production rate, Nutrient uptake rate, carbon/water reserves, a limiting-factor readout (Carbon-limited / Water-limited / Balanced), and counts + FPS.

## Performance

- Raw Three.js (no R3F), single `requestAnimationFrame` loop; params via a mutable ref so the loop never restarts; metrics pushed to React on a throttle (~6–7 Hz), never per frame.
- All sim state in preallocated typed arrays; one `InstancedMesh` per layer (branches/roots/leaves) with preallocated instance buffers → bounded memory.
- Only newly grown segments are written each frame; the full taper rewrite is throttled to ≤ 4 Hz and only when the structure changed.
- Space-colonization queries use a uniform-grid spatial hash over the small active growth front; attractor clouds are capped.
- `MeshLambertMaterial` (per-vertex lighting) for the instanced layers; pixel ratio capped at 2; full GL resource disposal on unmount / study switch.

## Files

- New: `src/studies/tree-growth/{types,simulation,renderer}.ts`, `TreeGrowth.tsx`, `index.tsx`
- New UI: `src/components/ui/toggle-group.tsx`, `src/components/ui/MetricBar.tsx`
- New: `src/studies/registry.ts`, `src/components/StudySwitcher.tsx`
- Modified: `src/App.tsx` (registry + switcher wiring), `package.json` (+`three`, `@types/three`)

## Testing

- `pnpm build` (tsc + vite) passes; new files lint-clean (a pre-existing `input.tsx` lint error on `main` is untouched).
- Headless logic tests confirmed the economy responds correctly: Sunlight=0 → photosynthesis 0 / Carbon-limited; Nutrients=0 → uptake 0 / Water-limited; allocation toggles strongly bias shoot vs root growth; mature tree settles to Balanced.
- Manual browser testing (recording above) verified: a green leafy canopy + roots grow in real time; Photosynthesis/Uptake bars respond live to Sunlight/Nutrients; the limiting-factor label flips appropriately; wind sway; layer toggles; replant; camera orbit/zoom; and study switching — with no console errors.

> Note: the demo recording runs at ~20fps because the cloud VM falls back to **software WebGL**; the instanced/throttled architecture runs at full refresh on real GPU hardware.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-014657ab-6604-4789-8ada-f830992d139b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-014657ab-6604-4789-8ada-f830992d139b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

